### PR TITLE
TERNCY-PP01: Add cfg.sensor_battery in homeassistant.js

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -1361,7 +1361,7 @@ const mapping = {
     '9290022169': [cfg.light_brightness_colortemp],
     'TERNCY-PP01': [
         cfg.sensor_temperature, cfg.binary_sensor_occupancy, cfg.sensor_illuminance, cfg.sensor_illuminance_lux,
-        cfg.sensor_click,
+        cfg.sensor_click, cfg.sensor_battery,
     ],
     'CR11S8UZ': [cfg.sensor_action],
     'RB 148 T': [cfg.light_brightness_colortemp],


### PR DESCRIPTION
The PP01 sends battery data. So we can also set up a sensor for it.